### PR TITLE
Fix nasty bug in bid logic

### DIFF
--- a/js/auctions.js
+++ b/js/auctions.js
@@ -172,18 +172,22 @@ function dataListenerCallback(data) {
   }
 }
 
+export function parseDoc(doc) {
+  // Parse flat document data into structured Object
+  let data = {};
+  for (const [key, details] of Object.entries(doc.data())) {
+    let [item, bid] = key.split("_").map((i) => Number(i.match(/\d+/)));
+    data[item] = data[item] || {};
+    data[item][bid] = details;
+  }
+  return data;
+}
+
 export function dataListener(callback) {
   // Listen for updates in active auctions
   onSnapshot(doc(db, "auction", "items"), (doc) => {
     console.debug("dataListener() read from auction/items");
-    // Parse flat document data into structured Object
-    let data = {};
-    for (const [key, details] of Object.entries(doc.data())) {
-      let [item, bid] = key.split("_").map((i) => Number(i.match(/\d+/)));
-      data[item] = data[item] || {};
-      data[item][bid] = details;
-    }
-    callback(data);
+    callback(parseDoc(doc));
   });
 }
 


### PR DESCRIPTION
The following bid logic did not guarantee the order of the the returned `bids` array:
```
let data = doc.data();
let itemId = `item${i.toString().padStart(5, "0")}`;
let bids = Object.keys(data).filter((key) => key.includes(itemId));
```
This happened because the `key`s are strings and iteration order of `Object` keys is [complicated](https://stackoverflow.com/a/5525820).

This PR reuses the data parsing used in `auctions.js` so that the keys are numbers, for which `Object` iteration is ordered and ascending.