### PR TITLE
Update build and deploy jobs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,13 +13,16 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [18, 20, 21]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: ${{ matrix.version }}
           cache: 'npm'
       - name: Install dependencies
         run: |
@@ -28,13 +31,17 @@ jobs:
       - name: Build
         run: npm run build
       - name: Setup Pages
+        if: github.ref == 'refs/heads/main' && matrix.version == '21'
         uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        if: github.ref == 'refs/heads/main' && matrix.version == '21'
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'
 
   deploy:
+    # Only deploy on main branch
+    if: github.ref == 'refs/heads/main'
     needs: build
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:


### PR DESCRIPTION
- Build on Node 18, 20 and 21 (all currently maintained versions)
- Deploy only using Node 21 on the main branch (preview deployments for PRs is not yet supported)