### PR TITLE
Fix cancel button in Sign Up modal

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -216,7 +216,7 @@ const SignUpModal = () => {
         </form>
       </div>
       <div className="modal-footer">
-        <button type="button" className="btn btn-secondary">
+        <button type="button" className="btn btn-secondary" onClick={closeModal}>
           Cancel
         </button>
         <button


### PR DESCRIPTION
Currently, when the user clicks on the cancel button, nothing happens.
This is a simple fix that allows the cancel button to close the sign up modal.